### PR TITLE
Meh metrics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### 0.12.0 Unreleased
+
+* Count metrics emit the difference between intervals, not the counter so as to
+    make down stream processing easier.
+* line.count is now lines.read.count, which makes more sense
+
 ### 0.11.0 2015-05-04 Edward Muller (edward@heroku.com)
 
 * Raise all errors to the top and use a standard reporting format in

--- a/reader.go
+++ b/reader.go
@@ -11,15 +11,15 @@ import (
 // LogLineReader performs the reading of lines from an io.ReadCloser, encapsulating
 // lines into a LogLine and emitting them on outbox
 type LogLineReader struct {
-	outbox      chan<- LogLine
-	lineCounter metrics.Counter
+	outbox    chan<- LogLine
+	linesRead metrics.Counter
 }
 
 // NewLogLineReader constructs a new reader with it's own Outbox.
 func NewLogLineReader(o chan<- LogLine, m metrics.Registry) LogLineReader {
 	return LogLineReader{
-		outbox:      o,
-		lineCounter: metrics.GetOrRegisterCounter("line.count", m),
+		outbox:    o,
+		linesRead: metrics.GetOrRegisterCounter("lines.read", m),
 	}
 }
 
@@ -43,5 +43,5 @@ func (rdr LogLineReader) ReadLogLines(input io.ReadCloser) error {
 // Enqueue a single log line and increment the line counters
 func (rdr LogLineReader) Enqueue(ll LogLine) {
 	rdr.outbox <- ll
-	rdr.lineCounter.Inc(1)
+	rdr.linesRead.Inc(1)
 }


### PR DESCRIPTION
Output difference between intervals

This makes it much easier to use the count metrics with splunk

Also adjust the line.count metric so that it's lines.read.count to
express better what it's counting.

/cc @voidlock @apg 

For your review.

The main thing I don't like here is that some metrics reset every interval, others don't. But there is no atomic way with go-metrics to get a snapshot and reset at the same time. I may PR that there, but I also want to fix the problem at hand faster than not.
