### PR TITLE
LoadReader to add a reader to the shuttle

### DIFF
--- a/cmd/log-shuttle/main.go
+++ b/cmd/log-shuttle/main.go
@@ -244,8 +244,9 @@ func main() {
 
 	go LogFmtMetricsEmitter(s.MetricsRegistry, config.StatsSource, config.StatsInterval, s.Logger)
 
-	// Blocks until os.Stdin is closed
+	// Blocks until os.Stdin errors
 	s.ReadLogLines(os.Stdin)
+	os.Stdin.Close()
 
 	// Shutdown the shuttle.
 	s.Land()

--- a/reader.go
+++ b/reader.go
@@ -23,8 +23,9 @@ func NewLogLineReader(o chan<- LogLine, m metrics.Registry) LogLineReader {
 	}
 }
 
-// ReadLogLines reads lines from the ReadCloser
-func (rdr LogLineReader) ReadLogLines(input io.ReadCloser) error {
+// ReadLogLines reads lines from the Reader and returns with an error if there
+// is an error
+func (rdr LogLineReader) ReadLogLines(input io.Reader) error {
 	rdrIo := bufio.NewReader(input)
 
 	for {
@@ -32,7 +33,6 @@ func (rdr LogLineReader) ReadLogLines(input io.ReadCloser) error {
 		currentLogTime := time.Now()
 
 		if err != nil {
-			input.Close()
 			return err
 		}
 

--- a/shuttle.go
+++ b/shuttle.go
@@ -1,6 +1,7 @@
 package shuttle
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"sync"
@@ -16,15 +17,16 @@ var (
 // Shuttle is the main entry point into the library
 type Shuttle struct {
 	LogLineReader
-	config           Config
-	LogLines         chan LogLine
-	Batches          chan Batch
-	MetricsRegistry  metrics.Registry
-	bWaiter, oWaiter *sync.WaitGroup
-	Drops, Lost      *Counter
-	NewFormatterFunc NewHTTPFormatterFunc
-	Logger           *log.Logger
-	ErrLogger        *log.Logger
+	config                    Config
+	LogLines                  chan LogLine
+	Batches                   chan Batch
+	readers                   []io.ReadCloser
+	MetricsRegistry           metrics.Registry
+	bWaiter, oWaiter, rWaiter *sync.WaitGroup
+	Drops, Lost               *Counter
+	NewFormatterFunc          NewHTTPFormatterFunc
+	Logger                    *log.Logger
+	ErrLogger                 *log.Logger
 }
 
 // NewShuttle returns a properly constructed Shuttle with a given config
@@ -41,8 +43,10 @@ func NewShuttle(config Config) *Shuttle {
 		Lost:             NewCounter(0),
 		MetricsRegistry:  mr,
 		NewFormatterFunc: config.FormatterFunc,
+		readers:          make([]io.ReadCloser, 0),
 		oWaiter:          new(sync.WaitGroup),
 		bWaiter:          new(sync.WaitGroup),
+		rWaiter:          new(sync.WaitGroup),
 		Logger:           discardLogger,
 		ErrLogger:        discardLogger,
 	}
@@ -81,10 +85,39 @@ func (s *Shuttle) startBatchers() {
 	}
 }
 
+// LoadReader into the shuttle for processing it's lines. Use this if you want
+// log-shuttle to track the readers for you.
+func (s *Shuttle) LoadReader(rdr io.ReadCloser) {
+	s.rWaiter.Add(1)
+	s.readers = append(s.readers, rdr)
+	go func() {
+		s.ReadLogLines(rdr)
+		s.rWaiter.Done()
+	}()
+}
+
+// CloseReaders closes all tracked readers.
+func (s *Shuttle) CloseReaders() []error {
+	errors := make([]error, 0, len(s.readers))
+	for _, closer := range s.readers {
+		errors = append(errors, closer.Close())
+	}
+	return errors
+}
+
+// DockReaders closes all tracked readers and waits for all reading go routines
+// to finish.
+func (s *Shuttle) DockReaders() []error {
+	errors := s.CloseReaders()
+	s.rWaiter.Wait()
+	return errors
+}
+
 // Land gracefully terminates the shuttle instance, ensuring that anything
 // read is batched and delivered. A panic is likely to happen if Land() is
 // called before any readers passed to any ReadLogLines() calls aren't closed.
 func (s *Shuttle) Land() {
+	s.DockReaders()
 	close(s.LogLines) // Close the log line channel, all of the batchers will stop once they are done
 	s.bWaiter.Wait()  // Wait for them to be done
 	close(s.Batches)  // Close the batch channel, all of the outlets will stop once they are done


### PR DESCRIPTION
This allows log-shuttle to track which readers have errored or not and
to control closing them down.

Fixes: #49