### PR TITLE
Fix mis-vendored file

### DIFF
--- a/Godeps/_workspace/src/github.com/rcrowley/go-metrics/cmd/metrics-example/metrics-example.go
+++ b/Godeps/_workspace/src/github.com/rcrowley/go-metrics/cmd/metrics-example/metrics-example.go
@@ -3,7 +3,8 @@ package main
 import (
 	"errors"
 	"github.com/heroku/log-shuttle/Godeps/_workspace/src/github.com/rcrowley/go-metrics"
-	"log" // "github.com/rcrowley/go-metrics/stathat"
+	// "github.com/rcrowley/go-metrics/stathat"
+	"log"
 	"math/rand"
 	"os"
 	// "syslog"


### PR DESCRIPTION
I revendored everything while testing an updated godep and this was the
difference. Older versions of godep could improperly handle comments in
imports and this is one case where it had problems. This bug is now
fixed in godep  : https://github.com/tools/godep/issues/216