### PR TITLE
Fix -skip-headers to not bomb out it with -input-format=rfc5424

### DIFF
--- a/cmd/log-shuttle/main.go
+++ b/cmd/log-shuttle/main.go
@@ -131,10 +131,14 @@ func parseFlags(c shuttle.Config) (shuttle.Config, error) {
 
 	if skipHeaders {
 		log.Println("Warning: Use of -skip-headers is deprecated, use -input-format=rfc5424 instead")
-		if c.InputFormat == shuttle.InputFormatRaw {
+		switch c.InputFormat {
+		case shuttle.InputFormatRaw:
+			// Massage InputFormat as that's what is used internally
 			c.InputFormat = shuttle.InputFormatRFC5424
-		} else {
-			return c, fmt.Errorf("Cannot use -skip-headers with anything except the default input format")
+		case shuttle.InputFormatRFC5424:
+			// NOOP
+		default:
+			return c, fmt.Errorf("Can only use -skip-headers with default input format or rfc5424")
 		}
 	}
 


### PR DESCRIPTION
They are basically saying the same thing and -skip-headers is
deprecated.

/cc @apg @voidlock @cyx @srid 

I'm going to need to deploy this so that I can fix up logdrain urls to splunk 