### PR TITLE
Protect from data races in test code

### DIFF
--- a/batcher_test.go
+++ b/batcher_test.go
@@ -17,6 +17,7 @@ func ProduceLogLines(count int, c chan<- LogLine) {
 }
 
 func BenchmarkBatcher(b *testing.B) {
+	config := newTestConfig()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()

--- a/http_outlet_test.go
+++ b/http_outlet_test.go
@@ -41,6 +41,8 @@ func TestOutletEOFRetry(t *testing.T) {
 	th := &testEOFHelper{maxCloses: 1}
 	ts := httptest.NewTLSServer(th)
 	defer ts.Close()
+
+	config := newTestConfig()
 	config.LogsURL = ts.URL
 	config.SkipVerify = true
 
@@ -68,6 +70,7 @@ func TestOutletEOFRetry(t *testing.T) {
 }
 
 func TestOutletEOFRetryMax(t *testing.T) {
+	config := newTestConfig()
 	th := &testEOFHelper{maxCloses: config.MaxAttempts}
 	ts := httptest.NewTLSServer(th)
 	defer ts.Close()

--- a/kinesis_formatter_test.go
+++ b/kinesis_formatter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestKinesisFormatter(t *testing.T) {
+	config := newTestConfig()
 	config.LogsURL = "https://key:secret@foo/Stream"
 	b := NewBatch(1)
 	b.Add(LogLineOne)
@@ -21,6 +22,7 @@ func TestKinesisFormatter(t *testing.T) {
 }
 
 func TestKinesisFormatterRequest(t *testing.T) {
+	config := newTestConfig()
 	config.LogsURL = "https://key:secret@kinesis.us-east-1.amazonaws.com/Stream"
 	b := NewBatch(1)
 	b.Add(LogLineOne)
@@ -41,6 +43,7 @@ func TestKinesisFormatterRequest(t *testing.T) {
 }
 
 func TestKinesisGzip(t *testing.T) {
+	config := newTestConfig()
 	config.LogsURL = "https://key:secret@foo/Stream"
 	b := NewBatch(1)
 	b.Add(LogLineOne)

--- a/kinesis_types_test.go
+++ b/kinesis_types_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestKinesisRecord_MarshalJSONToWriter(t *testing.T) {
+	config := newTestConfig()
 	llf := NewLogplexLineFormatter(LogLineOne, &config)
 	b := new(bytes.Buffer)
 	r := KinesisRecord{llf}

--- a/shuttle.go
+++ b/shuttle.go
@@ -109,11 +109,16 @@ func (s *Shuttle) CloseReaders() []error {
 	return errors
 }
 
+// WaitForReadersToFinish to finish reading
+func (s *Shuttle) WaitForReadersToFinish() {
+	s.rWaiter.Wait()
+}
+
 // DockReaders closes all tracked readers and waits for all reading go routines
 // to finish.
 func (s *Shuttle) DockReaders() []error {
 	errors := s.CloseReaders()
-	s.rWaiter.Wait()
+	s.WaitForReadersToFinish()
 	return errors
 }
 


### PR DESCRIPTION
Also add a test for output with eData.

There is a data race in the test code, this "fixes" it.