### PR TITLE
[kinesis-sharding] Distribute partition key to ensure records hit mul…

### DIFF
--- a/cmd/log-shuttle/main.go
+++ b/cmd/log-shuttle/main.go
@@ -111,6 +111,7 @@ func parseFlags(c shuttle.Config) (shuttle.Config, error) {
 	flag.IntVar(&c.FrontBuff, "front-buff", c.FrontBuff, "Number of messages to buffer in log-shuttle's input channel.")
 	flag.IntVar(&c.BackBuff, "back-buff", c.BackBuff, "Number of batches to buffer before dropping.")
 	flag.IntVar(&c.MaxLineLength, "max-line-length", c.MaxLineLength, "Number of bytes that the backend allows per line.")
+	flag.IntVar(&c.KinesisShards, "kinesis-shards", c.KinesisShards, "Number of shards for which to create unique parition keys.")
 
 	flag.Parse()
 

--- a/config.go
+++ b/config.go
@@ -40,6 +40,7 @@ const (
 	DefaultID            = ""
 	DefaultDrop          = true
 	DefaultUseGzip       = false
+	DefaultKinesisShards = 1
 )
 
 const (
@@ -70,6 +71,7 @@ type Config struct {
 	NumOutlets                          int
 	InputFormat                         int
 	MaxAttempts                         int
+	KinesisShards                       int
 	LogsURL                             string
 	Prival                              string
 	Version                             string
@@ -125,6 +127,7 @@ func NewConfig() Config {
 		FormatterFunc: DefaultFormatterFunc,
 		Drop:          DefaultDrop,
 		UseGzip:       DefaultUseGzip,
+		KinesisShards: DefaultKinesisShards,
 	}
 
 	shuttleConfig.ComputeHeader()

--- a/kinesis_types.go
+++ b/kinesis_types.go
@@ -3,7 +3,10 @@ package shuttle
 import (
 	"encoding/base64"
 	"io"
+	"strconv"
 )
+
+var shard int = 0
 
 // KinesisRecord is used to marshal LoglexLineFormatters to Kinesis Records for
 // the PutRecords API Call
@@ -16,8 +19,12 @@ type KinesisRecord struct {
 func (r KinesisRecord) WriteTo(w io.Writer) (n int64, err error) {
 	var t int
 	var t64 int64
+	var b string
 
-	t, err = w.Write([]byte(`{"PartitionKey":"` + r.llf.AppName() + `","Data":"`))
+	// Add an integer in the PartitionKey to enable distribution
+	// over multiple shards in the Kinesis stream.
+	b = `{"PartitionKey":"` + r.llf.AppName() + getShard() + `","Data":"`
+	t, err = w.Write([]byte(b))
 	n += int64(t)
 	if err != nil {
 		return
@@ -43,4 +50,15 @@ func (r KinesisRecord) WriteTo(w io.Writer) (n int64, err error) {
 // The same as Encoding.EncodedLen, but for int64
 func encodedLen(n int64) int64 {
 	return (n + 2) / 3 * 4
+}
+
+func getShard() (nextShard string) {
+	// 50 is the max number of shards possible. It is ok to have more
+	// partition keys than actual shards.
+	if shard >= 50 {
+		shard = 0
+	}
+	nextShard = strconv.Itoa(shard)
+	shard++
+	return
 }

--- a/kinesis_types_test.go
+++ b/kinesis_types_test.go
@@ -44,3 +44,58 @@ func TestKinesisRecord_MarshalJSONToWriter(t *testing.T) {
 		t.Fatal("Expected Data to be equal to reading all the formatted bytes of the log line, but wasn't.")
 	}
 }
+
+func TestKinesisRecordSharding(t *testing.T) {
+	config := newTestConfig()
+	config.KinesisShards = 2
+	llf := NewLogplexLineFormatter(LogLineOne, &config)
+	llf2 := NewLogplexLineFormatter(LogLineTwo, &config)
+	b := new(bytes.Buffer)
+	r := KinesisRecord{llf}
+	r2 := KinesisRecord{llf2}
+
+	_, err := r.WriteTo(b)
+	if err != nil {
+		t.Fatal("Unexpected error calling MarshalJSONToWriter: ", err)
+	}
+
+	tr := struct {
+		Data         []byte
+		PartitionKey string
+	}{}
+
+	t.Logf("%+q\n", b.Bytes())
+
+	if err := json.Unmarshal(b.Bytes(), &tr); err != nil {
+		t.Fatal("Unexpected error unmashalling KinesisRecord: ", err)
+	}
+
+	t.Logf("%+q\n", tr)
+
+	if tr.PartitionKey != "shuttle1" {
+		t.Fatal("Expected PartitonKey to not be empty, but was.")
+	}
+
+	b = new(bytes.Buffer)
+	_, err = r2.WriteTo(b)
+	if err != nil {
+		t.Fatal("Unexpected error calling MarshalJSONToWriter: ", err)
+	}
+
+	tr = struct {
+		Data         []byte
+		PartitionKey string
+	}{}
+
+	t.Logf("%+q\n", b.Bytes())
+
+	if err := json.Unmarshal(b.Bytes(), &tr); err != nil {
+		t.Fatal("Unexpected error unmashalling KinesisRecord: ", err)
+	}
+
+	t.Logf("%+q\n", tr)
+
+	if tr.PartitionKey != "shuttle2" {
+		t.Fatal("Expected PartitonKey to not be empty, but was.")
+	}
+}

--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -112,6 +112,7 @@ type LogplexLineFormatter struct {
 	line              []byte // the raw line bytes
 	header            string // the precomputed, length prefixed syslog frame header
 	inputFormat       int
+	shards            int // number of shards to use for Kinesis partition keys
 }
 
 // NewLogplexLineFormatter returns a new LogplexLineFormatter wrapping the provided LogLine
@@ -134,6 +135,7 @@ func NewLogplexLineFormatter(ll LogLine, config *Config) *LogplexLineFormatter {
 		line:        ll.line,
 		header:      header,
 		inputFormat: config.InputFormat,
+		shards: config.KinesisShards,
 	}
 }
 


### PR DESCRIPTION
…tiple shards.

According to the Kinesis documentation, when a producer puts records into Kinesis, the partition keys passed with the record are mapped to shards. If we only use one partition key for every record, it is only possible for the records from a given producer to hit one shard. 

This is a problem in practice because each shard has limited inbound throughput. I became aware of this problem when using log shuttle to produce records for an 8 shard stream, and noticed my consumers were only getting records from one shard. Once I deployed the changes in this PR, the records started flowing from multiple shards. The test suite also passes.

Thanks!
Nathan