### PR TITLE
Detangle Kinesis shard stuff from logplex formatter

### DIFF
--- a/kinesis_formatter.go
+++ b/kinesis_formatter.go
@@ -17,7 +17,6 @@ type KinesisFormatter struct {
 	records []KinesisRecord
 	keys    *aws4.Keys
 	url     *url.URL
-	shards  int
 	io.Reader
 }
 
@@ -38,7 +37,6 @@ func NewKinesisFormatter(b Batch, eData []errData, config *Config) HTTPFormatter
 	kf := &KinesisFormatter{
 		records: make([]KinesisRecord, 0, b.MsgCount()+len(eData)),
 		keys:    &aws4.Keys{AccessKey: awsKey, SecretKey: awsSecret},
-		shards:  config.KinesisShards,
 		url:     u,
 	}
 

--- a/kinesis_formatter.go
+++ b/kinesis_formatter.go
@@ -17,6 +17,7 @@ type KinesisFormatter struct {
 	records []KinesisRecord
 	keys    *aws4.Keys
 	url     *url.URL
+	shards  int
 	io.Reader
 }
 
@@ -37,15 +38,16 @@ func NewKinesisFormatter(b Batch, eData []errData, config *Config) HTTPFormatter
 	kf := &KinesisFormatter{
 		records: make([]KinesisRecord, 0, b.MsgCount()+len(eData)),
 		keys:    &aws4.Keys{AccessKey: awsKey, SecretKey: awsSecret},
+		shards:  config.KinesisShards,
 		url:     u,
 	}
 
 	for _, edata := range eData {
-		kf.records = append(kf.records, KinesisRecord{NewLogplexErrorFormatter(edata, config)})
+		kf.records = append(kf.records, KinesisRecord{llf: NewLogplexErrorFormatter(edata, config)})
 	}
 
 	for _, l := range b.logLines {
-		kf.records = append(kf.records, KinesisRecord{NewLogplexLineFormatter(l, config)})
+		kf.records = append(kf.records, KinesisRecord{llf: NewLogplexLineFormatter(l, config)})
 	}
 
 	recordsReader, recordsWriter := io.Pipe()
@@ -56,7 +58,10 @@ func NewKinesisFormatter(b Batch, eData []errData, config *Config) HTTPFormatter
 	)
 
 	go func() {
+		var cs int
 		for i, record := range kf.records {
+			cs = determineShard(cs, config.KinesisShards)
+			record.shard = cs
 			if _, err := record.WriteTo(recordsWriter); err != nil {
 				recordsWriter.CloseWithError(err)
 				return
@@ -72,6 +77,18 @@ func NewKinesisFormatter(b Batch, eData []errData, config *Config) HTTPFormatter
 	}()
 
 	return kf
+}
+
+// Given a current shard number and the number number of shards return the next shard number
+// In the case of 0 KinesisRecord does not add the shard number to the PartitionKey
+func determineShard(c, max int) int {
+	if max == 1 {
+		return 0
+	}
+	if c == max {
+		c = 0
+	}
+	return c + 1
 }
 
 // Request constructs a request for this formatter

--- a/kinesis_types_test.go
+++ b/kinesis_types_test.go
@@ -11,7 +11,7 @@ func TestKinesisRecord_MarshalJSONToWriter(t *testing.T) {
 	config := newTestConfig()
 	llf := NewLogplexLineFormatter(LogLineOne, &config)
 	b := new(bytes.Buffer)
-	r := KinesisRecord{llf}
+	r := KinesisRecord{llf: llf}
 
 	_, err := r.WriteTo(b)
 	if err != nil {
@@ -51,8 +51,8 @@ func TestKinesisRecordSharding(t *testing.T) {
 	llf := NewLogplexLineFormatter(LogLineOne, &config)
 	llf2 := NewLogplexLineFormatter(LogLineTwo, &config)
 	b := new(bytes.Buffer)
-	r := KinesisRecord{llf}
-	r2 := KinesisRecord{llf2}
+	r := KinesisRecord{llf: llf, shard: 1}
+	r2 := KinesisRecord{llf: llf2, shard: 2}
 
 	_, err := r.WriteTo(b)
 	if err != nil {
@@ -72,8 +72,9 @@ func TestKinesisRecordSharding(t *testing.T) {
 
 	t.Logf("%+q\n", tr)
 
-	if tr.PartitionKey != "shuttle1" {
-		t.Fatal("Expected PartitonKey to not be empty, but was.")
+	expected := "shuttle1"
+	if tr.PartitionKey != expected {
+		t.Fatalf("Expected PartitonKey to be `%s`, but was `%s`.", expected, tr.PartitionKey)
 	}
 
 	b = new(bytes.Buffer)

--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -112,7 +112,6 @@ type LogplexLineFormatter struct {
 	line              []byte // the raw line bytes
 	header            string // the precomputed, length prefixed syslog frame header
 	inputFormat       int
-	shards            int // number of shards to use for Kinesis partition keys
 }
 
 // NewLogplexLineFormatter returns a new LogplexLineFormatter wrapping the provided LogLine
@@ -135,7 +134,6 @@ func NewLogplexLineFormatter(ll LogLine, config *Config) *LogplexLineFormatter {
 		line:        ll.line,
 		header:      header,
 		inputFormat: config.InputFormat,
-		shards: config.KinesisShards,
 	}
 }
 


### PR DESCRIPTION
I don't know why I +1'd the commit that added that.

It's:

1. racy
2. mixes kinesis and logplex stuff together un-necessarily

I decided to use a batch level shard counter instead of doing a
package level variable. This won't produce the same results exactly, but
I don't think anyone is really relying on the previous behavior.