### PR TITLE
one more tweak for pre-v15 parity

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -66,6 +66,7 @@ func (rdr *LogLineReader) expireBatches() {
 
 		case <-rdr.timer.C:
 			rdr.mu.Lock()
+			rdr.batchFillTime.Update(rdr.timeOut)
 			rdr.deliverOrDropCurrent()
 			rdr.mu.Unlock()
 		}

--- a/reader.go
+++ b/reader.go
@@ -66,8 +66,7 @@ func (rdr *LogLineReader) expireBatches() {
 
 		case <-rdr.timer.C:
 			rdr.mu.Lock()
-			rdr.batchFillTime.Update(rdr.timeOut)
-			rdr.deliverOrDropCurrent()
+			rdr.deliverOrDropCurrent(rdr.timeOut)
 			rdr.mu.Unlock()
 		}
 	}
@@ -92,8 +91,7 @@ func (rdr *LogLineReader) ReadLines() error {
 			rdr.linesRead.Inc(1)
 			rdr.mu.Lock()
 			if full := rdr.b.Add(LogLine{line, currentLogTime}); full {
-				rdr.batchFillTime.UpdateSince(now)
-				rdr.deliverOrDropCurrent()
+				rdr.deliverOrDropCurrent(time.Since(now))
 			}
 			if rdr.b.MsgCount() == 1 { // First line so restart the timer
 				now = time.Now()
@@ -104,7 +102,7 @@ func (rdr *LogLineReader) ReadLines() error {
 
 		if err != nil {
 			rdr.mu.Lock()
-			rdr.deliverOrDropCurrent()
+			rdr.deliverOrDropCurrent(time.Since(now))
 			rdr.mu.Unlock()
 			close(rdr.close)
 			return err
@@ -113,7 +111,7 @@ func (rdr *LogLineReader) ReadLines() error {
 }
 
 // Should only be called when rdr.mu is held
-func (rdr *LogLineReader) deliverOrDropCurrent() {
+func (rdr *LogLineReader) deliverOrDropCurrent(d time.Duration) {
 	rdr.timer.Stop()
 	// There is the possibility of a new batch being expired while this is happening.
 	// so guard against queueing up an empty batch
@@ -130,6 +128,8 @@ func (rdr *LogLineReader) deliverOrDropCurrent() {
 			rdr.out <- rdr.b
 			rdr.linesBatchedCount.Inc(int64(c))
 		}
+
+		rdr.batchFillTime.Update(d)
 		rdr.b = NewBatch(rdr.batchSize)
 	}
 }


### PR DESCRIPTION
Another fix for #71. Prior to v15 log-shuttle would update `batch.fill`
anytime a batch was sent. This happened regardless of whether the batch
was full or not.