### PR TITLE
http_outlet: use just http.Client.Timeout

### DIFF
--- a/http_outlet.go
+++ b/http_outlet.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -65,10 +64,10 @@ func NewHTTPOutlet(s *Shuttle) *HTTPOutlet {
 		errLogger:        s.ErrLogger,
 		Logger:           s.Logger,
 		client: &http.Client{
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: s.config.SkipVerify},
-				ResponseHeaderTimeout: s.config.Timeout,
-				Dial: func(network, address string) (net.Conn, error) {
-					return net.DialTimeout(network, address, s.config.Timeout)
+			Timeout: s.config.Timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: s.config.SkipVerify,
 				},
 			},
 		},


### PR DESCRIPTION
[Timeout](https://golang.org/pkg/net/http/#Client.Timeout) covers the entire request and response exchange, including dialing.

I think this better covers the spirit of the Timeout field on Config.