### PR TITLE
credential leak remediation

### DIFF
--- a/cleanurl.go
+++ b/cleanurl.go
@@ -1,0 +1,17 @@
+package shuttle
+
+import "net/url"
+
+// extractCredentials extracts and scrubs basic auth credentials from a URL to
+// ensure that they never get logged.
+func extractCredentials(uri *url.URL) (*url.URL, string, string) {
+	cleanURL, _ := url.Parse(uri.String())
+	username := ""
+	password := ""
+	if cleanURL.User != nil {
+		username = uri.User.Username()
+		password, _ = uri.User.Password()
+	}
+	cleanURL.User = nil
+	return cleanURL, username, password
+}

--- a/cleanurl.go
+++ b/cleanurl.go
@@ -4,12 +4,16 @@ import "net/url"
 
 // extractCredentials extracts and scrubs basic auth credentials from a URL to
 // ensure that they never get logged.
-func extractCredentials(uri *url.URL) (cleanURL *url.URL, username string, password string) {
-	cleanURL, _ = url.Parse(uri.String())
+func extractCredentials(uri string) (cleanURL *url.URL, username string, password string, err error) {
+	cleanURL, err = url.Parse(uri)
+	if err != nil {
+		return
+	}
+
 	if cleanURL.User != nil {
-		username = uri.User.Username()
-		password, _ = uri.User.Password()
+		username = cleanURL.User.Username()
+		password, _ = cleanURL.User.Password()
 	}
 	cleanURL.User = nil
-	return cleanURL, username, password
+	return cleanURL, username, password, nil
 }

--- a/cleanurl.go
+++ b/cleanurl.go
@@ -4,10 +4,8 @@ import "net/url"
 
 // extractCredentials extracts and scrubs basic auth credentials from a URL to
 // ensure that they never get logged.
-func extractCredentials(uri *url.URL) (*url.URL, string, string) {
-	cleanURL, _ := url.Parse(uri.String())
-	username := ""
-	password := ""
+func extractCredentials(uri *url.URL) (cleanURL *url.URL, username string, password string) {
+	cleanURL, _ = url.Parse(uri.String())
 	if cleanURL.User != nil {
 		username = uri.User.Username()
 		password, _ = uri.User.Password()

--- a/http_outlet_test.go
+++ b/http_outlet_test.go
@@ -46,7 +46,6 @@ func TestCreds(t *testing.T) {
 	b := NewBatch(1)
 	b.Add(LogLineOne)
 	b.Add(LogLineTwo)
-	log.Printf("config = %+v", config)
 	br := NewLogplexBatchFormatter(b, noErrData, &config)
 	r, err := br.Request()
 	if err != nil {

--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -76,11 +77,21 @@ func NewLogplexBatchFormatter(b Batch, eData []errData, config *Config) HTTPForm
 // Request returns a properly constructed *http.Request, complete with headers
 // and ContentLength set.
 func (bf *LogplexBatchFormatter) Request() (*http.Request, error) {
-	req, err := http.NewRequest("POST", bf.stringURL, bf)
+	u, err := url.Parse(bf.stringURL)
 	if err != nil {
 		return nil, err
 	}
 
+	u, user, pass := extractCredentials(u)
+
+	req, err := http.NewRequest("POST", u.String(), bf)
+	if err != nil {
+		return nil, err
+	}
+
+	if user != "" || pass != "" {
+		req.SetBasicAuth(user, pass)
+	}
 	req.Header = bf.headers
 
 	return req, nil

--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 )
@@ -77,12 +76,10 @@ func NewLogplexBatchFormatter(b Batch, eData []errData, config *Config) HTTPForm
 // Request returns a properly constructed *http.Request, complete with headers
 // and ContentLength set.
 func (bf *LogplexBatchFormatter) Request() (*http.Request, error) {
-	u, err := url.Parse(bf.stringURL)
+	u, user, pass, err := extractCredentials(bf.stringURL)
 	if err != nil {
 		return nil, err
 	}
-
-	u, user, pass := extractCredentials(u)
 
 	req, err := http.NewRequest("POST", u.String(), bf)
 	if err != nil {

--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -89,10 +89,12 @@ func (bf *LogplexBatchFormatter) Request() (*http.Request, error) {
 		return nil, err
 	}
 
+	// Assign headers before we potentially BasicAuth
+	req.Header = bf.headers
+
 	if user != "" || pass != "" {
 		req.SetBasicAuth(user, pass)
 	}
-	req.Header = bf.headers
 
 	return req, nil
 }


### PR DESCRIPTION
Ensure that the logplex formatter doesn't leak out credentials in the error log.