### PR TITLE
 Don't leak creds in the logplex formatter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 sudo: required
 go:
-- 1.7
+- 1.9.3
 script:
 - make test
 before_deploy:

--- a/http_outlet_test.go
+++ b/http_outlet_test.go
@@ -227,7 +227,6 @@ func TestTimeout(t *testing.T) {
 	if msg := logCapture.Bytes(); !bytes.Contains(msg, []byte("retry=true")) {
 		t.Errorf("expected log message to contain `retry=trye`, got %q", msg)
 	}
-
 }
 
 func TestIsEOF(t *testing.T) {

--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -28,7 +28,7 @@ type LogplexBatchFormatter struct {
 }
 
 type urlCacheItem struct {
-	*url.URL               // *url.URL with user credentials removed
+	url.URL                // url.URL with user credentials removed
 	urls, user, pwd string // rendered url and the user and password, if any.
 }
 
@@ -55,10 +55,9 @@ func sanatizedURL(s string) urlCacheItem {
 		c.user = u.User.Username()
 		c.pwd, _ = u.User.Password()
 	}
-	u.User = nil         // zero out user
-	c.URL = new(url.URL) // allocate a new url
-	*c.URL = *u          // copy the value, not the pointer
-	c.urls = u.String()  // save a copy as a string
+	u.User = nil // zero out user to remove any creds
+	c.URL = *u
+	c.urls = u.String() // save a copy as a string
 
 	cmu.Lock()
 	if len(urlCache) > URLCacheSizeMax {
@@ -66,6 +65,7 @@ func sanatizedURL(s string) urlCacheItem {
 	}
 	urlCache[s] = c
 	cmu.Unlock()
+
 	return c
 }
 

--- a/shuttle_test.go
+++ b/shuttle_test.go
@@ -320,10 +320,6 @@ func TestRequestId(t *testing.T) {
 	}
 }
 
-type lenner interface {
-	Len() int
-}
-
 func BenchmarkPipeline(b *testing.B) {
 	th := new(noopTestHelper)
 	ts := httptest.NewServer(th)

--- a/shuttle_test.go
+++ b/shuttle_test.go
@@ -29,7 +29,7 @@ Ac lorem aliquam placerat.
 func newTestConfig() Config {
 	// Defaults should be good for most tests
 	config := NewConfig()
-	config.LogsURL = "http://"
+	config.LogsURL = "http://localhost/"
 	return config
 }
 


### PR DESCRIPTION
Additional small changes:

* Optimize the struct layout (reduces padding) of LogplexLineFormatter &
  LogplexBatchFormatter.
* Remove unused contentLength field
* Remove unused lenner interface in tests
* Add a creation benchmark
* cache parsing results (saves 248 bytes and 3 allocations per batch created)
* Cache has default size of 100 items before it's replaced.
* Update travis (and released versions to a modern Go)