### PR TITLE
should print out L13s to splunk

### DIFF
--- a/logplex_formatter.go
+++ b/logplex_formatter.go
@@ -234,6 +234,7 @@ func NewLogplexErrorFormatter(err errData, config *Config) *LogplexLineFormatter
 		err.count,
 		what,
 		err.since.UTC().Format(LogplexBatchTimeFormat))
+	config.ErrLogger.Printf("at=NewLogplexErrorFormatter, msg=%s", msg)
 	return &LogplexLineFormatter{
 		line:        []byte(msg),
 		header:      fmt.Sprintf("%d ", len(msg)),


### PR DESCRIPTION
L13s should also be reported in Splunk. Will make it easier to debug if we are seeing this output and can compare the request responses with the timestamps of these L13s.

Related to https://github.com/heroku/dogwood/pull/2243