### PR TITLE
Include more details in http post failures

### DIFF
--- a/http_outlet.go
+++ b/http_outlet.go
@@ -1,7 +1,6 @@
 package shuttle
 
 import (
-	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -135,16 +134,10 @@ func (h *HTTPOutlet) post(formatter HTTPFormatter) error {
 		return err
 	}
 
-	body := req.Body
-	defer body.Close()
-
-	buff, err := ioutil.ReadAll(body)
-	if err != nil {
-		return err
+	cr := &countingReader{
+		reader: req.Body,
 	}
-
-	contentLength := len(buff)
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(buff))
+	req.Body = ioutil.NopCloser(cr)
 
 	uuid := req.Header.Get("X-Request-Id")
 	req.Header.Add("User-Agent", h.userAgent)
@@ -165,9 +158,9 @@ func (h *HTTPOutlet) post(formatter HTTPFormatter) error {
 	case status >= 400:
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			h.errLogger.Printf("at=post request_id=%q content_length=%d msgcount=%d status=%d reading_body=true error=%q\n", uuid, contentLength, formatter.MsgCount(), status, err)
+			h.errLogger.Printf("at=post request_id=%q content_length=%d msgcount=%d status=%d reading_body=true error=%q\n", uuid, cr.count, formatter.MsgCount(), status, err)
 		} else {
-			h.errLogger.Printf("at=post request_id=%q content_length=%d msgcount=%d status=%d body=%q\n", uuid, contentLength, formatter.MsgCount(), status, body)
+			h.errLogger.Printf("at=post request_id=%q content_length=%d msgcount=%d status=%d body=%q\n", uuid, cr.count, formatter.MsgCount(), status, body)
 		}
 
 	default:
@@ -199,4 +192,17 @@ func isEOF(err error) bool {
 
 	uerr, ok := err.(*url.Error)
 	return ok && uerr.Err == io.EOF
+}
+
+// countingReader stores the total bytes read from an underlying reader.
+type countingReader struct {
+	reader io.Reader
+	count  int64
+}
+
+// Read implements the io.Reader interface.
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.reader.Read(p)
+	c.count += int64(n)
+	return n, err
 }

--- a/http_outlet.go
+++ b/http_outlet.go
@@ -153,9 +153,9 @@ func (h *HTTPOutlet) post(formatter HTTPFormatter) error {
 	case status >= 400:
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			h.errLogger.Printf("at=post request_id=%q status=%d reading_body=true error=%q\n", uuid, status, err)
+			h.errLogger.Printf("at=post request_id=%q request_content_length=%d status=%d reading_body=true error=%q\n", uuid, req.ContentLength, status, err)
 		} else {
-			h.errLogger.Printf("at=post request_id=%q status=%d body=%q\n", uuid, status, body)
+			h.errLogger.Printf("at=post request_id=%q request_content_length=%d status=%d body=%q\n", uuid, req.ContentLength, status, body)
 		}
 
 	default:

--- a/http_outlet_test.go
+++ b/http_outlet_test.go
@@ -298,6 +298,7 @@ func TestPostError(t *testing.T) {
 	for _, field := range []string{
 		"status=413",
 		"msgcount=1",
+		"content_length=",
 	} {
 		if msg := logCapture.Bytes(); !bytes.Contains(msg, []byte(field)) {
 			t.Errorf("expected log message to contain `%s`, got %q", field, msg)

--- a/http_outlet_test.go
+++ b/http_outlet_test.go
@@ -269,3 +269,39 @@ func TestIsEOF(t *testing.T) {
 		t.Errorf("got isEOF(%+v) = true, want false", uerr)
 	}
 }
+
+func TestPostError(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+	}))
+	defer ts.Close()
+
+	config := newTestConfig()
+	config.LogsURL = ts.URL
+	config.SkipVerify = true
+	config.MaxAttempts = 1
+
+	var logCapture bytes.Buffer
+	s := NewShuttle(config)
+	s.ErrLogger = log.New(&logCapture, "", 0)
+
+	outlet := NewHTTPOutlet(s)
+
+	batch := NewBatch(config.BatchSize)
+	batch.Add(LogLine{[]byte("Hello"), time.Now()})
+	outlet.retryPost(batch)
+
+	if lost := s.Lost.Read(); lost > 0 {
+		t.Errorf("expected lost of 0, got %d", lost)
+	}
+
+	for _, field := range []string{
+		"status=413",
+		"msgcount=1",
+	} {
+		if msg := logCapture.Bytes(); !bytes.Contains(msg, []byte(field)) {
+			t.Errorf("expected log message to contain `%s`, got %q", field, msg)
+		}
+	}
+
+}


### PR DESCRIPTION
During some investigations around failures to post to a particular log drain, we realized there wasn't much visibility into the specifics of a failed post. Namely we needed to know the total size of the request body, because the custom log drain in use had some unusually low limitations (64k byte limit). Knowing the number of messages it contained was also beneficial as it allowed us to get a rough idea of the size of each individual log line emitted from the process.

This PR:
- Wraps the body of the request returned by the formatter in a reader that will keep track of the total number of bytes read.
- Include `content_length` and `msgcount` fields in the errors