### PR TITLE
Disable CGO for the binary that will be put in the Alpine container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ver: glv
 	$(eval VERSION := $(shell echo ${GO_LINKER_VALUE} | sed s/^v//))
 
 docker: ldflags ver clean-docker-build
-	${GO_BUILD_ENV} go build -v -o .docker_build/log-shuttle ${LDFLAGS} ./cmd/log-shuttle
+	${GO_BUILD_ENV} CGO_ENABLED=0 go build -v -o .docker_build/log-shuttle ${LDFLAGS} ./cmd/log-shuttle
 	docker build -t heroku/log-shuttle:${VERSION} ./
 	${MAKE} clean-docker-build
 


### PR DESCRIPTION
Fixes #92 

Without this CGO builds are enabled and links are created to libs in /lib64 which doesn't exist on Alpine.

Before https://github.com/heroku/log-shuttle/commit/4476c45b1db56435ad09aac660c93c7306e9e1d6 the binary was statically linked and a change to the travis env vars seems to have resulted in this linked version being producted.

This change ensures we build with CGO_ENABLED=0 in all places, both locally and in Travis.