### PR TITLE
feat: support bearer auth for logplex formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tags
 log-shuttle.exe
 log-shuttle.test
 .env
+.out

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 GO_LINKER_SYMBOL := main.version
 GO_BUILD_ENV := GOOS=linux GOARCH=amd64
+OUTDIR := .out
 
 all: test
 
 test:
 	go test -v ./...
 	go test -v -race ./...
+
+build: clean ldflags ver
+	go build -v -o ${OUTDIR}/log-shuttle ${LDFLAGS} ./cmd/log-shuttle
+
+clean:
+	rm -rf ${OUTDIR}
 
 install: ldflags
 	go install -v ${LDFLAGS} ./...

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Add -bearer-token to support Bearer auth
+
 ### 0.18.0 2019-02-14 Edward Muller (emuller@salesforce.com)
 
 * Build with 1.11.5

--- a/cmd/log-shuttle/main.go
+++ b/cmd/log-shuttle/main.go
@@ -93,6 +93,7 @@ func parseFlags(c shuttle.Config) (shuttle.Config, error) {
 	flag.StringVar(&c.Msgid, "msgid", c.Msgid, "The msgid field for the syslog header.")
 	flag.StringVar(&c.LogsURL, "logs-url", c.LogsURL, "The receiver of the log data.")
 	flag.StringVar(&c.StatsSource, "stats-source", c.StatsSource, "When emitting stats, add source=<stats-source> to the stats.")
+	flag.StringVar(&c.BearerAuthToken, "bearer-token", c.BearerAuthToken, "Token for bearer auth, overrides basic auth in logs-url")
 
 	flag.StringVar(&inputFormat, "input-format", "raw", "'raw' (default; newline termined text), 'rfc5424' (newline terminated rfc5424), 'lprfc5424' (length prefixed rfc5424).")
 	flag.StringVar(&statsAddr, "stats-addr", "", "DEPRECATED, WILL BE REMOVED, HAS NO EFFECT.")

--- a/config.go
+++ b/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	Appname                             string
 	Msgid                               string
 	StatsSource                         string
+	BearerAuthToken                     string
 	SkipVerify                          bool
 	Verbose                             bool
 	UseGzip                             bool


### PR DESCRIPTION
This commit adds support for injecting a bearer auth token  for the logplex formatter, via a command line option that takes it in. If the token is not present, we fall back to basic auth if present.

Ref: W-17702967