### PR TITLE
maint: update actions, dist targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,17 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+          runner: ["ubuntu-latest", "ubuntu-24.04-arm"]
+    runs-on: ${{ matrix.runner }}
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        env:
-          ImageOS: ubuntu20
-        with:
-          go-verion: 1.18
-          check-latests: true
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.1
+          check-latest: true
       - name: Run Test
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.1
+          check-latest: true
       - name: Make Debs
         run: |
           make debs
@@ -23,24 +28,25 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.3.7
       - name: Push to packagecloud.io
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
           ARTIFACT: log-shuttle_${{ env.DEB_VERSION }}_amd64.deb
         run: |
           gem install package_cloud
-          package_cloud push heroku/open/ubuntu/trusty ./${{ env.ARTIFACT }}
+          package_cloud push heroku/open/ubuntu/focal ./${{ env.ARTIFACT }}
+          package_cloud push heroku/open/ubuntu/noble ./${{ env.ARTIFACT }}
 
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Push to Docker Hub
         run: make docker-push

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* Update GHA
+* Update dist targets to focal and noble
+
 ### 0.21.0 2025-02-03 Matt Blewitt (matthew.blewitt@salesforce.com)
 
 * Add -bearer-token to support Bearer auth


### PR DESCRIPTION
This commit updates all the outdated GHA configurations, and adds ARM support for the CI run - release action needs some more work.

This commit also adds new dist targets for `noble` and `focal`, retiring `trusty` as a target.