### PR TITLE
maint: remove ncipollo/release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,6 @@ jobs:
         run: |
           make debs
           echo DEB_VERSION=$(git describe --tags --always | sed s/^v//) >> $GITHUB_ENV
-      - name: Make Release
-        uses: ncipollo/release-action@v1
-        env:
-          ARTIFACT: log-shuttle_${{ env.DEB_VERSION }}_amd64.deb
-        with:
-          artifacts: ${{ env.ARTIFACT }}
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Remove ncipollo/release-action
+
 ### 0.21.1 2025-02-07 Matt Blewitt (matthew.blewitt@salesforce.com)
 
 * Update GHA


### PR DESCRIPTION
This commit removes the `ncipollo/release-action` action, due to IP restrictions on the `heroku` org.