### PR TITLE
Build the Ubuntu debs on the Correct Ubuntu Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-          runner: ["ubuntu-latest", "ubuntu-24.04-arm", "ubuntu-20.04", "ubuntu-24.04-arm"]
+          runner: ["ubuntu-latest", "ubuntu-24.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-          runner: ["ubuntu-latest", "ubuntu-24.04-arm"]
+          runner: ["ubuntu-latest", "ubuntu-24.04-arm", "ubuntu-20.04", "ubuntu-24.04-arm"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-20.04
+            codename: focal
+          - runner: ubuntu-24.04
+            codename: noble
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -29,8 +36,7 @@ jobs:
           ARTIFACT: log-shuttle_${{ env.DEB_VERSION }}_amd64.deb
         run: |
           gem install package_cloud
-          package_cloud push heroku/open/ubuntu/focal ./${{ env.ARTIFACT }}
-          package_cloud push heroku/open/ubuntu/noble ./${{ env.ARTIFACT }}
+          package_cloud push heroku/open/ubuntu/${{ matrix.codename }} ./${{ env.ARTIFACT }}
 
   docker:
     runs-on: ubuntu-latest

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Build the Ubuntu debs on the Correct Ubuntu Version
+
 ### 0.21.2 2025-02-07 Matt Blewitt (matthew.blewitt@salesforce.com)
 
 * Remove ncipollo/release-action


### PR DESCRIPTION
Since #114 , we are encountering a GLIB version issue on Ubuntu Focal 20.04 machines, because we are building on a 24.04 machine. This correctly builds the ubuntu repository version on a matching runner version, so that they should be compatible.

```
$ log-shuttle --version
log-shuttle: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by log-shuttle)
log-shuttle: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by log-shuttle)
```