### PR TITLE
Release 0.22.0 - Fix glib Ubuntu Build Version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### 0.22.0 2025-02-17 Dan Starner (dstarner@salesforce.com)
+
 * Build the Ubuntu debs on the Correct Ubuntu Version
 
 ### 0.21.2 2025-02-07 Matt Blewitt (matthew.blewitt@salesforce.com)


### PR DESCRIPTION
Updates the changelog in preparation to release #115 .