### PR TITLE
Disable cgo for the purpose of an omni-linux binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-20.04
+            codename: focal
+          - runner: ubuntu-24.04
+            codename: noble
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -29,8 +36,7 @@ jobs:
           ARTIFACT: log-shuttle_${{ env.DEB_VERSION }}_amd64.deb
         run: |
           gem install package_cloud
-          package_cloud push heroku/open/ubuntu/focal ./${{ env.ARTIFACT }}
-          package_cloud push heroku/open/ubuntu/noble ./${{ env.ARTIFACT }}
+          package_cloud push heroku/open/ubuntu/${{ matrix.codename }} ./${{ env.ARTIFACT }}
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-20.04
-            codename: focal
-          - runner: ubuntu-24.04
-            codename: noble
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -36,7 +29,8 @@ jobs:
           ARTIFACT: log-shuttle_${{ env.DEB_VERSION }}_amd64.deb
         run: |
           gem install package_cloud
-          package_cloud push heroku/open/ubuntu/${{ matrix.codename }} ./${{ env.ARTIFACT }}
+          package_cloud push heroku/open/ubuntu/focal ./${{ env.ARTIFACT }}
+          package_cloud push heroku/open/ubuntu/noble ./${{ env.ARTIFACT }}
 
   docker:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	go test -v -race ./...
 
 build: clean ldflags ver
-	go build -v -o ${OUTDIR}/log-shuttle ${LDFLAGS} ./cmd/log-shuttle
+	CGO_ENABLED=0 go build -v -o ${OUTDIR}/log-shuttle ${LDFLAGS} ./cmd/log-shuttle
 
 clean:
 	rm -rf ${OUTDIR}
@@ -35,7 +35,7 @@ glv:
 	$(eval GO_LINKER_VALUE := $(shell git describe --tags --always))
 
 ldflags: glv
-	$(eval LDFLAGS := -ldflags "-X ${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}")
+	$(eval LDFLAGS := -ldflags "-X ${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE} -extldflags=-static")
 
 ver: glv
 	$(eval VERSION := $(shell echo ${GO_LINKER_VALUE} | sed s/^v//))

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### 0.22.0 2025-02-17 Dan Starner (dstarner@salesforce.com)
 
-* Build the Ubuntu debs on the Correct Ubuntu Version
+* Disable cgo for the purpose of an omni-linux binary (#117)
+* Build the Ubuntu debs on the Correct Ubuntu Version (#115)
 
 ### 0.21.2 2025-02-07 Matt Blewitt (matthew.blewitt@salesforce.com)
 


### PR DESCRIPTION
Thanks @mble-sfdc for the code and test for this one. It was tested within a Docker container

```
$ ldd .out/log-shuttle 
	not a dynamic executable
$ echo "foobar" | .out/log-shuttle -input-format=rfc5424 -appname app -hostname [REDACTED] -bearer-token [REDACTED] -logs-url http://localhost:8080/post

log-shuttle: 2025/02/17 16:00:48 at=post retry=true msgcount=1 inbox.length=0 request_id="351a32fc-9341-4f19-b2c6-ec4954c4556a" attempts=1 error="Post \"http://localhost:8080/post\": dial tcp [::1]:8080: connect: connection refused" errtype="*url.Error"
```