### PR TITLE
CGO_ENABLED=0 on Debian Builds to Make Installing Easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO_LINKER_SYMBOL := main.version
-GO_BUILD_ENV := GOOS=linux GOARCH=amd64
+GO_BUILD_ENV := GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 OUTDIR := .out
 
 all: test

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,12 @@ require (
 	github.com/pborman/uuid v0.0.0-20150824212802-cccd189d45f7
 	github.com/pebbe/util v0.0.0-20140716220158-e0e04dfe647c
 	github.com/rcrowley/go-metrics v0.0.0-20141108142129-dee209f2455f
+)
+
+require (
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 )
 
-go 1.13
+go 1.21

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,46 +1,57 @@
 # github.com/aws/aws-sdk-go v1.21.9
+## explicit
 github.com/aws/aws-sdk-go/aws
-github.com/aws/aws-sdk-go/aws/session
-github.com/aws/aws-sdk-go/aws/signer/v4
-github.com/aws/aws-sdk-go/service/cloudwatchlogs
 github.com/aws/aws-sdk-go/aws/awserr
-github.com/aws/aws-sdk-go/aws/credentials
-github.com/aws/aws-sdk-go/aws/endpoints
-github.com/aws/aws-sdk-go/internal/sdkio
+github.com/aws/aws-sdk-go/aws/awsutil
 github.com/aws/aws-sdk-go/aws/client
+github.com/aws/aws-sdk-go/aws/client/metadata
 github.com/aws/aws-sdk-go/aws/corehandlers
+github.com/aws/aws-sdk-go/aws/credentials
+github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
+github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
 github.com/aws/aws-sdk-go/aws/credentials/processcreds
 github.com/aws/aws-sdk-go/aws/credentials/stscreds
 github.com/aws/aws-sdk-go/aws/csm
 github.com/aws/aws-sdk-go/aws/defaults
+github.com/aws/aws-sdk-go/aws/ec2metadata
+github.com/aws/aws-sdk-go/aws/endpoints
 github.com/aws/aws-sdk-go/aws/request
+github.com/aws/aws-sdk-go/aws/session
+github.com/aws/aws-sdk-go/aws/signer/v4
 github.com/aws/aws-sdk-go/internal/ini
-github.com/aws/aws-sdk-go/internal/shareddefaults
-github.com/aws/aws-sdk-go/private/protocol/rest
-github.com/aws/aws-sdk-go/aws/awsutil
-github.com/aws/aws-sdk-go/aws/client/metadata
-github.com/aws/aws-sdk-go/private/protocol
-github.com/aws/aws-sdk-go/private/protocol/jsonrpc
+github.com/aws/aws-sdk-go/internal/sdkio
 github.com/aws/aws-sdk-go/internal/sdkrand
+github.com/aws/aws-sdk-go/internal/sdkuri
+github.com/aws/aws-sdk-go/internal/shareddefaults
+github.com/aws/aws-sdk-go/private/protocol
+github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
+github.com/aws/aws-sdk-go/private/protocol/jsonrpc
+github.com/aws/aws-sdk-go/private/protocol/query
+github.com/aws/aws-sdk-go/private/protocol/query/queryutil
+github.com/aws/aws-sdk-go/private/protocol/rest
+github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
+github.com/aws/aws-sdk-go/service/cloudwatchlogs
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
-github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
-github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
-github.com/aws/aws-sdk-go/aws/ec2metadata
-github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
-github.com/aws/aws-sdk-go/private/protocol/query
-github.com/aws/aws-sdk-go/internal/sdkuri
-github.com/aws/aws-sdk-go/private/protocol/query/queryutil
-github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
 # github.com/bmizerany/aws4 v0.0.0-20141025110357-5fb2e7239626
+## explicit
 github.com/bmizerany/aws4
 # github.com/heroku/slog v0.0.0-20150110001655-7746152d9340
+## explicit
 github.com/heroku/slog
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+## explicit
 github.com/jmespath/go-jmespath
 # github.com/pborman/uuid v0.0.0-20150824212802-cccd189d45f7
+## explicit
 github.com/pborman/uuid
 # github.com/pebbe/util v0.0.0-20140716220158-e0e04dfe647c
+## explicit
 github.com/pebbe/util
 # github.com/rcrowley/go-metrics v0.0.0-20141108142129-dee209f2455f
+## explicit
 github.com/rcrowley/go-metrics
+# github.com/stretchr/testify v1.3.0
+## explicit
+# golang.org/x/net v0.0.0-20190311183353-d8887717615a
+## explicit


### PR DESCRIPTION
Installation is a pain right not because of the linking needed by `gcc` and `cgo`. Disabling it should hopefully break install errors that I am seeing elsewhere.

```
 > [10/11] RUN go install github.com/heroku/log-shuttle/...@latest:
1.060 go: downloading github.com/heroku/log-shuttle v0.22.0
1.781 go: downloading github.com/aws/aws-sdk-go v1.21.9
1.782 go: downloading github.com/bmizerany/aws4 v0.0.0-20141025110357-5fb2e7239626
1.821 go: downloading github.com/heroku/slog v0.0.0-20150110001655-7746152d9340
1.821 go: downloading github.com/pborman/uuid v0.0.0-20150824212802-cccd189d45f7
1.821 go: downloading github.com/rcrowley/go-metrics v0.0.0-20141108142129-dee209f2455f
1.825 go: downloading github.com/pebbe/util v0.0.0-20140716220158-e0e04dfe647c
6.332 go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
10.25 # runtime/cgo
10.25 gcc: error: unrecognized command line option '-m64'
```