### PR TITLE
Stop publishing Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,3 @@ jobs:
         run: |
           gem install package_cloud
           package_cloud push heroku/open/ubuntu/${{ matrix.codename }} ./${{ env.ARTIFACT }}
-
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Push to Docker Hub
-        run: make docker-push

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,5 @@ docker: ldflags ver clean-docker-build
 clean-docker-build:
 	rm -rf .docker_build
 
-docker-push: docker ver
-	docker push heroku/log-shuttle:${VERSION}
-
 tmp:
 	$(eval TMP := $(shell mktemp -d -t log_shuttle.XXXXX))


### PR DESCRIPTION
Since:
- SSO enforcement on the `heroku` Docker Hub org is soon going to break the service user currently used to publish the image.
- The `heroku/log-shuttle` image on Docker Hub is currently private and not being pulled by anyone.
- Since this is a Go project, the more common way people will be consuming it will be from GitHub as either a Go module dependency or by `go install`ing the CLI from the GitHub URL.

If in the future there is a wish to start publishing a Docker image again, I would recommend using GitHub's container registry instead, which has smoother integration with GitHub Actions and also doesn't suffer from Docker Hub's increasingly restrictive rate limits:
https://docs.docker.com/docker-hub/usage/

GUS-W-18890192.