### PR TITLE
chore: Git2Gus will create WIs for dependabot PRs

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,0 +1,10 @@
+{
+  "productTag": "a1aEE000000q0WzYAI",
+  "defaultBuild": "Heroku Runtime Telemetry Build",
+  "issueTypeLabels": {
+    "feature": "USER STORY",
+    "regression": "BUG P0",
+    "bug": "BUG P2",
+    "dependencies": "BUG P2"
+  }
+}


### PR DESCRIPTION
Dependabot PRs are opened automatically. These are easy to lose sight of. Here, we configure git2gus to create a P2 Bug for anything labeled with `dependencies`.

Git2GUS: https://lwc-gus-bot.herokuapp.com/