### PR TITLE
Correct `GUSINFO` team and product tag in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 #ECCN:Open Source
-#GUSINFO:Heroku Runtime Telemetry,Heroku Logplex OSS
+#GUSINFO:Heroku Observability,Heroku Logplex
 * @heroku/runtime-telemetry


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` names a product tag (`Heroku Logplex OSS`) that does not exist in GUS. This change sets it to `Heroku Observability,Heroku Logplex`.

This correction was suggested by Claude Code, based on the GitHub owner team (`@heroku/runtime-telemetry`) and the matching active product tag in GUS. The reviewer should confirm the new product tag is correct and the most appropriate one for this component.

GUS-W-23525396.